### PR TITLE
Fixes Issue 3 (Hoodle does not create ~/.hoodle.d) 

### DIFF
--- a/src/Hoodle/Coroutine/Callback.hs
+++ b/src/Hoodle/Coroutine/Callback.hs
@@ -15,6 +15,7 @@ module Hoodle.Coroutine.Callback where
 import Control.Concurrent
 import Control.Exception
 import Data.Time
+import System.Directory
 import System.Environment
 import System.FilePath
 import System.Locale
@@ -45,7 +46,9 @@ patternerr e = errorlog (show e)
 errorlog :: String -> IO ()
 errorlog str = do 
   homepath <- getEnv "HOME"
-  outh <- openFile (homepath </> ".hoodle.d" </> "error.log") AppendMode 
+  let dir = homepath </> ".hoodle.d"
+  createDirectoryIfMissing False dir
+  outh <- openFile (dir </> "error.log") AppendMode 
   utctime <- getCurrentTime 
   let timestr = formatTime defaultTimeLocale "%F %H:%M:%S %Z" utctime
   hPutStr outh (timestr ++ " : " )  

--- a/src/Hoodle/GUI.hs
+++ b/src/Hoodle/GUI.hs
@@ -22,6 +22,7 @@ import qualified Data.IntMap as M
 import           Data.Maybe
 -- import           Data.Time
 import           Graphics.UI.Gtk hiding (get,set)
+import           System.Directory
 import           System.Environment
 import           System.FilePath
 import           System.IO
@@ -91,7 +92,9 @@ startGUI mfname mhook = do
                       mainGUI 
   mainaction `catch` \(_e :: SomeException) -> do 
     homepath <- getEnv "HOME"
-    outh <- openFile (homepath </> ".hoodle.d" </> "error.log") WriteMode 
+    let dir = homepath </> ".hoodle.d"
+    createDirectoryIfMissing False dir
+    outh <- openFile (dir </> "error.log") WriteMode 
     hPutStrLn outh "error occured"
     hClose outh 
   return ()


### PR DESCRIPTION
Hoodle does not create the directory ~/.hoodle.d if it doesn't exist. When it breaks, it tries to write to ~/.hoodle/error.log, but since ~/.hoodle.d does not exist, the file is not created and no real information about the problem is reported. On the command line, it simply says that openFile failed.

The commit I include fixes that by calling createDirectoryIfMissing before trying to open the file.
